### PR TITLE
Change config flag location

### DIFF
--- a/Board Configuration Files/TH3D_EZBoardLite/Firmware/Marlin/Configuration.h
+++ b/Board Configuration Files/TH3D_EZBoardLite/Firmware/Marlin/Configuration.h
@@ -3,9 +3,11 @@
  * THIS VERSION IS NOT FOR PRODUCTION USE AT THIS TIME AND ONLY AVAILABLE FOR TESTING PURPOSES
  * NO IMPLIED SUPPORT OR WARRANTY IS PROVIDED WITH THIS FIRMWARE RELEASE
  */
-//#@CONFIGURATION_START_FLAG
+
 #pragma once
 #define CONFIGURATION_H_VERSION 020006
+
+//#@CONFIGURATION_START_FLAG
 
 //===========================================================================
 //============================ TH3D Configuration ===========================
@@ -275,6 +277,8 @@
 //===========================================================================
 // **********************  END CONFIGURATION SETTINGS   *********************
 //===========================================================================
+
+//#@CONFIGURATION_END_FLAG
 
 /**
  * ****************************DO NOT TOUCH ANYTHING BELOW THIS COMMENT**************************
@@ -643,4 +647,3 @@
  */
  
 #include "Configuration_backend.h"
-//#@CONFIGURATION_END_FLAG


### PR DESCRIPTION

### Description
Change config flag locations. This flag will be used by compile server to auto generate the template of config file .
The flags will mark where are the start and end of user editable configs. 

