### PR TITLE
Update platformio.ini

### DIFF
--- a/Board_Configs/CrealityV4X/Firmware/platformio.ini
+++ b/Board_Configs/CrealityV4X/Firmware/platformio.ini
@@ -20,7 +20,7 @@
 #
 # GD32 CPUs
 # GD32F303RCT6_creality_maple - F303 RCT6 256K CPU
-# GD32F303RET6_creality_maple - F303 RET6 256K CPU
+# GD32F303RET6_creality_maple - F303 RET6 512K CPU
 #
 # WARNING: Flashing a 512K build on a 256K CPU can result in lockups or instability. Make sure you check your CPU before building for a 512K version.
 


### PR DESCRIPTION
The GD32F303RET6 is 512k, not 256k
https://www.gigadevice.com/microcontroller/gd32f303ret6/
I am a seasoned developer, but very new to this code so I don't know if there are other places where this value could be set incorrectly.  I did look, but I honestly couldn't determine where Flash Memory size was set.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Updating the comment block for the Creatlity Ender v4x platformio.ini file to correct the stated flash size 

### Benefits

Clarity to the end user.  It was confusing as to the difference, so I looked up the two chips in question, I currently have a GD32F303RET6 version of this board.

### Related Issues

I am not sure if there is an issue against this, but the comment was incorrect.