### PR TITLE
Added support for using EzBoard V2 FAN2 as a secondary part cooling fan

### DIFF
--- a/Firmware/Marlin/Configuration_adv.h
+++ b/Firmware/Marlin/Configuration_adv.h
@@ -667,8 +667,8 @@
 /**
  * Use one of the PWM fans as a redundant part-cooling fan
  */
-#if ENABLED(EZBOARD_FAN2_PART_COOLING_MODE)
-#define REDUNDANT_PART_COOLING_FAN 1  // Index of the fan to sync with FAN 0.
+#if ENABLED(EZBOARD_V2) && ENABLED(EZBOARD_FAN2_PART_COOLING_MODE)
+  #define REDUNDANT_PART_COOLING_FAN 1  // Index of the fan to sync with FAN 0.
 #endif
 // @section extruder
 

--- a/Firmware/Marlin/Configuration_adv.h
+++ b/Firmware/Marlin/Configuration_adv.h
@@ -549,7 +549,7 @@
   #endif
 #endif
 
-#if (ENABLED(EZBOARD) || ENABLED(EZBOARD_V2)) && DISABLED(USE_CONTROLLER_FAN) && DISABLED(EZBOARD_FAN2_HOTEND_MODE)
+#if (ENABLED(EZBOARD) || ENABLED(EZBOARD_V2)) && DISABLED(USE_CONTROLLER_FAN) && DISABLED(EZBOARD_FAN2_HOTEND_MODE) && DISABLED(EZBOARD_FAN2_PART_COOLING_MODE)
   #define USE_CONTROLLER_FAN
   #if ENABLED(EZBOARD_V2)
     #define CONTROLLER_FAN_PIN       PC7
@@ -667,8 +667,9 @@
 /**
  * Use one of the PWM fans as a redundant part-cooling fan
  */
-//#define REDUNDANT_PART_COOLING_FAN 2  // Index of the fan to sync with FAN 0.
-
+#if ENABLED(EZBOARD_FAN2_PART_COOLING_MODE)
+#define REDUNDANT_PART_COOLING_FAN 1  // Index of the fan to sync with FAN 0.
+#endif
 // @section extruder
 
 /**


### PR DESCRIPTION
### Description

This PR adds support for a new Configuration.h setting "EZBOARD_FAN2_PART_COOLING_MODE".

Adding this setting to your Configuration.h allows you to use FAN2 port on Ezboard V2 as a second layer fan, kept in sync with FAN1.  This leverages Marlin's existing "REDUNDANT_PART_COOLING_FAN" option.

This is similar to the "EZBOARD_FAN2_HOTEND_MODE" config that already exists, but the difference is it syncs FAN2 to FAN1 instead of driving FAN2 based on hot end temps.


### Requirements

Ezboard V2

### Benefits

EzBoard V2 is advertised as a drop in replacement for the Ender 3 MAX.

On the Ender 3 Max with stock 4.2.2 board, the hot end has three fans - An "Always on" hot end fan, and two layer fans. The two layer fans are wired to K-FAN1 and K- FAN2. FAN1 and FAN2 are kept in sync on stock Ender 3 Max firmware. 

The hot end fan and the controller fan are both wired to the "Always On" port so neither needs the FAN2 port.

Having this option available allows a true "drop and replace" experience with the Ender 3 Max and any other printers with multiple layer fans.

Note: I've only tested this with EzBoard V2 and an Ender 3 Max.

### Configurations

To test:

Add `#define EZBOARD_FAN2_PART_COOLING_MODE` to Configuration.h on an EzBoard V2. Plug a 2nd layer fan into FAN2 port.

### Related Issues

N/A
